### PR TITLE
fix regex replace

### DIFF
--- a/bus-core/src/main/java/org/aoju/bus/core/utils/PatternUtils.java
+++ b/bus-core/src/main/java/org/aoju/bus/core/utils/PatternUtils.java
@@ -195,15 +195,11 @@ public class PatternUtils {
             return null;
         }
 
-        HashSet<String> varNums = findAll(RegEx.GROUP_VAR, template, 1, new HashSet<>());
-
         Matcher matcher = pattern.matcher(content);
         if (matcher.find()) {
-            for (String var : varNums) {
-                int group = Integer.parseInt(var);
-                template = template.replace(Symbol.DOLLAR + var, matcher.group(group));
-            }
-            return template;
+            final StringBuffer sb = new StringBuffer();
+            matcher.appendReplacement(sb, template);
+            return sb.toString();
         }
         return null;
     }
@@ -519,23 +515,7 @@ public class PatternUtils {
         }
 
         final Matcher matcher = pattern.matcher(content);
-        boolean result = matcher.find();
-        if (result) {
-            final Set<String> varNums = findAll(RegEx.GROUP_VAR, replacementTemplate, 1, new HashSet<>());
-            final StringBuffer sb = new StringBuffer();
-            do {
-                String replacement = replacementTemplate;
-                for (String var : varNums) {
-                    int group = Integer.parseInt(var);
-                    replacement = replacement.replace(Symbol.DOLLAR + var, matcher.group(group));
-                }
-                matcher.appendReplacement(sb, escape(replacement));
-                result = matcher.find();
-            } while (result);
-            matcher.appendTail(sb);
-            return sb.toString();
-        }
-        return content;
+        return matcher.replaceAll(replacementTemplate);
     }
 
     /**


### PR DESCRIPTION
- 有些情况下: ```.replace("$1","$2").replace("$2","other")```  产生的结果类似```replace("$1","other")```

https://github.com/aoju/bus/blob/23862f324483aa203c361297e10a927cd8e3da46/bus-core/src/main/java/org/aoju/bus/core/utils/PatternUtils.java#L204

- 另外`Matcher#appendReplacement`总是对`replacement`做一次遍历, 所以自行处理`replacement`的效益似乎没有想象中的高.而且需要对`replacement`进行`escape`以防止`replacement`中再次处理

```java
    public Matcher appendReplacement(StringBuffer sb, String replacement) {

        // If no match, return error
        if (first < 0)
            throw new IllegalStateException("No match available");

        // Process substitution string to replace group references with groups
        int cursor = 0;
        StringBuilder result = new StringBuilder();

        while (cursor < replacement.length()) {
            char nextChar = replacement.charAt(cursor);
            if (nextChar == '\\') {
                cursor++;
                if (cursor == replacement.length())
                    throw new IllegalArgumentException(
                        "character to be escaped is missing");
                nextChar = replacement.charAt(cursor);
                result.append(nextChar);
                cursor++;
            } else if (nextChar == '$') {
                // Skip past $
                cursor++;
                // Throw IAE if this "$" is the last character in replacement
                if (cursor == replacement.length())
                   throw new IllegalArgumentException(
                        "Illegal group reference: group index is missing");
                nextChar = replacement.charAt(cursor);
                int refNum = -1;
                if (nextChar == '{') {
                    cursor++;
                    StringBuilder gsb = new StringBuilder();
                    while (cursor < replacement.length()) {
                        nextChar = replacement.charAt(cursor);
                        if (ASCII.isLower(nextChar) ||
                            ASCII.isUpper(nextChar) ||
                            ASCII.isDigit(nextChar)) {
                            gsb.append(nextChar);
                            cursor++;
                        } else {
                            break;
                        }
                    }
                    if (gsb.length() == 0)
                        throw new IllegalArgumentException(
                            "named capturing group has 0 length name");
                    if (nextChar != '}')
                        throw new IllegalArgumentException(
                            "named capturing group is missing trailing '}'");
                    String gname = gsb.toString();
                    if (ASCII.isDigit(gname.charAt(0)))
                        throw new IllegalArgumentException(
                            "capturing group name {" + gname +
                            "} starts with digit character");
                    if (!parentPattern.namedGroups().containsKey(gname))
                        throw new IllegalArgumentException(
                            "No group with name {" + gname + "}");
                    refNum = parentPattern.namedGroups().get(gname);
                    cursor++;
                } else {
                    // The first number is always a group
                    refNum = (int)nextChar - '0';
                    if ((refNum < 0)||(refNum > 9))
                        throw new IllegalArgumentException(
                            "Illegal group reference");
                    cursor++;
                    // Capture the largest legal group string
                    boolean done = false;
                    while (!done) {
                        if (cursor >= replacement.length()) {
                            break;
                        }
                        int nextDigit = replacement.charAt(cursor) - '0';
                        if ((nextDigit < 0)||(nextDigit > 9)) { // not a number
                            break;
                        }
                        int newRefNum = (refNum * 10) + nextDigit;
                        if (groupCount() < newRefNum) {
                            done = true;
                        } else {
                            refNum = newRefNum;
                            cursor++;
                        }
                    }
                }
                // Append group
                if (start(refNum) != -1 && end(refNum) != -1)
                    result.append(text, start(refNum), end(refNum));
            } else {
                result.append(nextChar);
                cursor++;
            }
        }
        // Append the intervening text
        sb.append(text, lastAppendPosition, first);
        // Append the match substitution
        sb.append(result);

        lastAppendPosition = last;
        return this;
    }

```

---

## test code:

```java
package org.aoju.bus.core.utils;

public class PatternUtilsTest {
    public static void main(String[] args) {
        System.out.println(PatternUtils.replaceAll("name:$3age:$2sex:$1", "name:(.*)age:(.+)sex:(.+)", "sex:$3 age:$2 name:$1"));
        System.out.println(PatternUtils.replaceAll("2013年5月", "(.*?)年(.*?)月", "$1-$2"));
        System.out.println(PatternUtils.extractMulti("name:(.*)age:(.+)sex:(.+)", "name:$3age:$2sex:$1", "sex:$3 age:$2 name:$1"));
        System.out.println(PatternUtils.extractMulti("(.*?)年(.*?)月", "2013年5月", "$1-$2"));
    }
}

```
---

### before output:
```text
sex:$1 age:$2 name:$1
2013-5
sex:$1 age:$2 name:$1
2013-5
```

---

### after output:
```
sex:$1 age:$2 name:$3
2013-5
sex:$1 age:$2 name:$3
2013-5
```
---
- 为了尽量减少插件大小，我无法完整引入`bus`, 所以我单独重构了一份[RexUtils.kt](https://github.com/tangcent/easy-api/blob/feature/rule_parse/idea-plugin/src/main/kotlin/com/itangcent/idea/plugin/utils/RexUtils.kt)为插件规则提供正则相关工具方法.
如果有何不妥，请告知我，我将另外寻求解决方案.
---

- 另外，是否考虑增加单元测试?
- Feel free to close this PR if it's not an expected solutions.