### PR TITLE
:sparkles: 修改validate包中香港手机号命名，升级storage中华为obs依赖过期问题

### DIFF
--- a/bus-core/src/main/java/org/aoju/bus/core/lang/RegEx.java
+++ b/bus-core/src/main/java/org/aoju/bus/core/lang/RegEx.java
@@ -162,8 +162,8 @@ public class RegEx {
      * 中国澳门 +853 Macao
      * 中国台湾 +886 Taiwan
      */
-    public final static String MOBILE__PATTERN = "(?:0|852|\\+852)?\\d{8}";
-    public final static Pattern MOBILE_HK = Pattern.compile(MOBILE__PATTERN);
+    public final static String MOBILE_HK_PATTERN = "(?:0|852|\\+852)?\\d{8}";
+    public final static Pattern MOBILE_HK = Pattern.compile(MOBILE_HK_PATTERN);
 
     /**
      * 中国澳门移动电话

--- a/bus-storage/pom.xml
+++ b/bus-storage/pom.xml
@@ -45,7 +45,7 @@
         <lombok.version>1.18.22</lombok.version>
         <aliyun.oss.version>3.4.2</aliyun.oss.version>
         <baidu.bos.version>0.10.48</baidu.bos.version>
-        <huawei.oss.version>3.0.2</huawei.oss.version>
+        <huawei.oss.version>3.21.8</huawei.oss.version>
         <jd.oss.version>1.11.136</jd.oss.version>
         <minio.oss.version>3.0.12</minio.oss.version>
         <qiniu.oss.version>7.2.28</qiniu.oss.version>
@@ -94,7 +94,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.huawei.storage</groupId>
+            <groupId>com.huaweicloud</groupId>
             <artifactId>esdk-obs-java</artifactId>
             <version>${huawei.oss.version}</version>
             <optional>true</optional>

--- a/bus-validate/src/main/java/org/aoju/bus/validate/Validated.java
+++ b/bus-validate/src/main/java/org/aoju/bus/validate/Validated.java
@@ -151,14 +151,14 @@ public class Validated extends Provider {
     private List<Property> resolve(Annotation[] annotations) {
         List<Property> list = new ArrayList<>();
         for (Annotation annotation : annotations) {
-            if (this.isAnnotation(annotation)) {
+            if (isAnnotation(annotation)) {
                 Property property = build(annotation, this.object);
                 list.add(property);
             }
         }
         if (ObjectKit.isNotEmpty(this.object)) {
             Class<?> clazz = this.object.getClass();
-            List<Annotation> clazzAnnotations = this.getAnnotation(clazz);
+            List<Annotation> clazzAnnotations = getAnnotation(clazz);
             for (Annotation annotation : clazzAnnotations) {
                 Property property = build(annotation, this.object);
                 list.add(property);
@@ -187,8 +187,6 @@ public class Validated extends Provider {
                 context.setInside(((Valid) annotation).inside());
                 context.setField(((Valid) annotation).value());
                 context.setSkip(((Valid) annotation).skip());
-            } else if (annotation instanceof Group) {
-                context.addGroups(((Group) annotation).value());
             } else if (annotation instanceof Group) {
                 context.addGroups(((Group) annotation).value());
             } else if (annotation instanceof ValidEx) {
@@ -228,7 +226,7 @@ public class Validated extends Provider {
      * @return 校验器属性对象
      */
     public Property build(Annotation annotation, Object object) {
-        Assert.isTrue(this.isAnnotation(annotation), "尝试从非校验注解上获取信息:" + annotation);
+        Assert.isTrue(isAnnotation(annotation), "尝试从非校验注解上获取信息:" + annotation);
         Class<? extends Annotation> annotationType = annotation.annotationType();
         try {
             String[] groups = (String[]) annotationType.getMethod(Builder.GROUP).invoke(annotation);
@@ -265,7 +263,7 @@ public class Validated extends Provider {
             }
             Annotation[] parentAnnos = annotationType.getAnnotations();
             for (Annotation anno : parentAnnos) {
-                if (this.isAnnotation(anno)) {
+                if (isAnnotation(anno)) {
                     property.addParentProperty(build(anno, object));
                 } else if (anno instanceof Array) {
                     property.setArray(true);


### PR DESCRIPTION
1、validate包中正则属性命名，对于香港手机号正则属性命名与其他地区格式保持一致，修改为MOBILE_HK_PATTERN
2、对于华为obs存储的sdk包已经过期，可以升级为下面依赖，在此选择的是非bundle版本最新版本3.21.8
```
<dependency>
   <groupId>com.huaweicloud</groupId>
   <artifactId>esdk-obs-java-bundle</artifactId>
   <version>[3.21.8,)</version>
</dependency>
<!--若您的项目对三方依赖占用空间大小较为敏感，可使用下方代码引用非 bundle 版 SDK。具体差别见说明-->
<!--<dependency>-->
<!--	<groupId>com.huaweicloud</groupId>-->
<!--	<artifactId>esdk-obs-java</artifactId>-->
<!--	<version>[3.21.8,)</version>-->
<!--</dependency>-->

```